### PR TITLE
Tolerate files instead of modules in node_modules

### DIFF
--- a/src/lib/moduleHierarchyVerifier.ts
+++ b/src/lib/moduleHierarchyVerifier.ts
@@ -58,6 +58,8 @@ export class ModuleHierarchyVerifier {
         } catch (e) {
             if (e && e.code == 'ENOENT') {
                 // this package has no child modules.
+            } else if (e && e.code == 'ENOTDIR') {
+                // this is not a package (e.g. .yarn-integrity file)
             } else {
                 throw e;
             }


### PR DESCRIPTION
In some cases, there could be files instead of module folders inside node_modules, in which case the verification process currently fails:
```
> yarn verify
yarn run v1.3.2
$ rimraf dist && tsc && node dist/index.js verify . --full
Error: ENOTDIR: not a directory, scandir 'node_modules/.yarn-integrity/node_modules'
    at Error (native)
error Command failed with exit code 1.
```
In my case, it is due to the .yarn-integrity file (generated by yarn).
Funnily, it made me learn the existence of "yarn check --integrity", which seems to do part of pkgsign's duty: https://yarnpkg.com/lang/en/docs/cli/check/